### PR TITLE
Implement sticky white nav with dropdown and employment page

### DIFF
--- a/employment.html
+++ b/employment.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Employment Opportunities - Recycle WV</title>
+  <meta name="description" content="Join the team at Recycle WV." />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            brand: {
+              50:  '#ffffff',
+              100: '#2C663D',
+              500: '#2C663D',
+              600: '#2C663D',
+              700: '#2C663D'
+            }
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="font-sans antialiased text-black scroll-smooth">
+  <nav class="sticky top-0 z-20 bg-white mx-auto flex max-w-7xl items-center justify-between px-6 py-4 lg:px-8 text-black shadow">
+    <a href="index.html#home"><img src="logo.jpg" alt="Recycle WV logo" class="h-8 w-auto"></a>
+    <ul class="hidden md:flex gap-8 text-sm">
+      <li><a href="index.html#services" class="hover:text-brand-100">Services</a></li>
+      <li><a href="index.html#materials" class="hover:text-brand-100">Materials</a></li>
+      <li><a href="index.html#process" class="hover:text-brand-100">How&nbsp;It&nbsp;Works</a></li>
+      <li><a href="index.html#contact" class="hover:text-brand-100">Contact</a></li>
+    </ul>
+    <a href="tel:13044251788" class="inline-flex items-center gap-2 rounded-md bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600 md:ml-8">
+      Call&nbsp;Now
+    </a>
+    <div class="relative" id="dropdown">
+      <button onclick="toggleDropdown()" class="ml-4 inline-flex items-center gap-1 text-sm font-medium hover:text-brand-600">
+        More
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.584l3.71-4.353a.75.75 0 011.14.976l-4.25 5a.75.75 0 01-1.14 0l-4.25-5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+        </svg>
+      </button>
+      <ul id="dropdownMenu" class="absolute right-0 mt-2 hidden w-48 rounded-md bg-white shadow-lg">
+        <li><a href="employment.html" class="block px-4 py-2 hover:bg-gray-100">Employment Opportunities</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <header class="bg-brand-100 py-20 text-center text-white">
+    <h1 class="text-4xl font-bold">Employment Opportunities</h1>
+  </header>
+
+  <main class="mx-auto max-w-3xl p-6">
+    <p class="mb-4">Recycle WV is always looking for dedicated team members. If you're interested in joining us, please send your resume to <a href="mailto:jobs@recyclewv.com" class="text-brand-600 underline">jobs@recyclewv.com</a>.</p>
+  </main>
+
+  <footer class="bg-black py-8 text-center text-sm text-white">
+    © 2025 Recycle WV | All rights reserved | Website crafted with ♥ in WV
+  </footer>
+
+  <script src="https://unpkg.com/smoothscroll-polyfill@0.4.4/dist/smoothscroll.min.js"></script>
+  <script>smoothscroll.polyfill();</script>
+  <script>
+    function toggleDropdown() {
+      document.getElementById("dropdownMenu").classList.toggle("hidden");
+    }
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -28,24 +28,35 @@
   </script>
 </head>
 <body class="font-sans antialiased text-black scroll-smooth">
+  <nav class="sticky top-0 z-20 bg-white mx-auto flex max-w-7xl items-center justify-between px-6 py-4 lg:px-8 text-black shadow">
+    <a href="index.html#home"><img src="logo.jpg" alt="Recycle WV logo" class="h-8 w-auto"></a>
+    <ul class="hidden md:flex gap-8 text-sm">
+      <li><a href="index.html#services" class="hover:text-brand-100">Services</a></li>
+      <li><a href="index.html#materials" class="hover:text-brand-100">Materials</a></li>
+      <li><a href="index.html#process" class="hover:text-brand-100">How&nbsp;It&nbsp;Works</a></li>
+      <li><a href="index.html#contact" class="hover:text-brand-100">Contact</a></li>
+    </ul>
+    <a href="tel:13044251788" class="inline-flex items-center gap-2 rounded-md bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600 md:ml-8">
+      Call&nbsp;Now
+    </a>
+    <div class="relative" id="dropdown">
+      <button onclick="toggleDropdown()" class="ml-4 inline-flex items-center gap-1 text-sm font-medium hover:text-brand-600">
+        More
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.584l3.71-4.353a.75.75 0 011.14.976l-4.25 5a.75.75 0 01-1.14 0l-4.25-5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+        </svg>
+      </button>
+      <ul id="dropdownMenu" class="absolute right-0 mt-2 hidden w-48 rounded-md bg-white shadow-lg">
+        <li><a href="employment.html" class="block px-4 py-2 hover:bg-gray-100">Employment Opportunities</a></li>
+      </ul>
+    </div>
+  </nav>
   <!-- ========== HERO ========== -->
   <header id="home" class="relative isolate bg-black">
     <img src="https://images.unsplash.com/photo-1581091012184-3ac1ac53289e?q=80&w=1920&auto=format&fit=crop" alt="Scrap metal piles ready for recycling"
          class="absolute inset-0 -z-10 h-full w-full object-cover opacity-60" />
     <div class="absolute inset-0 -z-10 bg-black/70"></div>
 
-    <nav class="sticky top-0 z-10 bg-black bg-opacity-90 backdrop-blur-sm mx-auto flex max-w-7xl items-center justify-between px-6 py-4 lg:px-8 text-white">
-      <a href="#home"><img src="logo.jpg" alt="Recycle WV logo" class="h-8 w-auto"></a>
-      <ul class="hidden md:flex gap-8 text-sm">
-        <li><a href="#services" class="hover:text-brand-100">Services</a></li>
-        <li><a href="#materials" class="hover:text-brand-100">Materials</a></li>
-        <li><a href="#process"  class="hover:text-brand-100">How&nbsp;It&nbsp;Works</a></li>
-        <li><a href="#contact"  class="hover:text-brand-100">Contact</a></li>
-      </ul>
-      <a href="tel:13044251788" class="inline-flex items-center gap-2 rounded-md bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600 md:ml-8">
-        Call Now
-      </a>
-    </nav>
 
     <div class="mx-auto max-w-3xl py-32 px-6 text-center text-white lg:px-8">
       <h1 class="text-4xl font-extrabold sm:text-6xl leading-tight">
@@ -244,5 +255,10 @@
   <!-- Smooth‑scroll polyfill for Safari / iOS -->
   <script src="https://unpkg.com/smoothscroll-polyfill@0.4.4/dist/smoothscroll.min.js"></script>
   <script>smoothscroll.polyfill();</script>
+  <script>
+    function toggleDropdown() {
+      document.getElementById("dropdownMenu").classList.toggle("hidden");
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- make nav sticky across entire site instead of only inside hero
- switch nav background to solid white
- add dropdown with link to employment page
- create employment.html with same nav layout

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685b31eab24083298b04915731231557