### PR TITLE
Update employment page with job links and hero image

### DIFF
--- a/employment.html
+++ b/employment.html
@@ -24,7 +24,7 @@
     }
   </script>
 </head>
-<body class="font-sans antialiased text-black scroll-smooth">
+<body class="font-sans antialiased text-black scroll-smooth flex flex-col min-h-screen">
   <nav class="sticky top-0 z-20 bg-white mx-auto flex max-w-7xl items-center justify-between px-6 py-4 lg:px-8 text-black shadow">
     <a href="index.html#home"><img src="logo.jpg" alt="Recycle WV logo" class="h-8 w-auto"></a>
     <ul class="hidden md:flex gap-8 text-sm">
@@ -49,12 +49,22 @@
     </div>
   </nav>
 
-  <header class="bg-brand-100 py-20 text-center text-white">
-    <h1 class="text-4xl font-bold">Employment Opportunities</h1>
+  <header class="relative isolate bg-black">
+    <img src="assets/employment-hero.jpg" alt="Join the Recycle WV team" class="absolute inset-0 -z-10 h-full w-full object-cover opacity-60" />
+    <div class="absolute inset-0 -z-10 bg-black/70"></div>
+    <div class="mx-auto max-w-3xl py-20 px-6 text-center text-white lg:px-8">
+      <h1 class="text-4xl font-bold">Employment Opportunities</h1>
+    </div>
   </header>
 
-  <main class="mx-auto max-w-3xl p-6">
+  <main class="mx-auto max-w-3xl p-6 flex-grow">
     <p class="mb-4">Recycle WV is always looking for dedicated team members. If you're interested in joining us, please send your resume to <a href="mailto:jobs@recyclewv.com" class="text-brand-600 underline">jobs@recyclewv.com</a>.</p>
+
+    <div class="my-8 flex flex-col gap-4">
+      <a href="https://www.indeed.com/cmp/Recycle-Wv-1/jobs" target="_blank" class="inline-block rounded-md bg-brand-500 px-6 py-3 text-center font-semibold text-white hover:bg-brand-600">View Open Positions</a>
+      <a href="assets/job-application.pdf" download class="inline-block rounded-md border border-brand-500 px-6 py-3 text-center font-semibold text-brand-500 hover:bg-brand-50">Download Job Application</a>
+      <a href="assets/driver-application.pdf" download class="inline-block rounded-md border border-brand-500 px-6 py-3 text-center font-semibold text-brand-500 hover:bg-brand-50">Download Driver Application</a>
+    </div>
   </main>
 
   <footer class="bg-black py-8 text-center text-sm text-white">


### PR DESCRIPTION
## Summary
- create `assets` directory for uploaded files
- add hero image reference on Employment page
- add button linking to Indeed for current openings
- provide download links for Job and Driver applications
- adjust page layout so footer stays at the bottom

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b3425e23883298c071c626af893ab