### PR TITLE
Add employment menu item & mobile dropdown

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -1,3 +1,3 @@
-<footer class="bg-black py-8 text-center text-sm text-white">
+<footer class="bg-white py-8 text-center text-sm text-black">
   © 2025 Recycle WV | All rights reserved | Website crafted with ♥ in WV
 </footer>

--- a/nav.html
+++ b/nav.html
@@ -5,20 +5,25 @@
     <li><a href="index.html#materials" class="hover:text-brand-100">Materials</a></li>
     <li><a href="index.html#process" class="hover:text-brand-100">How&nbsp;It&nbsp;Works</a></li>
     <li><a href="index.html#contact" class="hover:text-brand-100">Contact</a></li>
+    <li><a href="employment.html" class="hover:text-brand-100">Employment</a></li>
   </ul>
   <div class="ml-auto flex items-center">
     <a href="tel:13044251788" class="inline-flex items-center gap-2 rounded-md bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600">
       Call&nbsp;Now
     </a>
-    <div class="relative ml-4" id="dropdown">
+    <div class="relative ml-4 md:hidden" id="dropdown">
       <button onclick="toggleDropdown()" class="inline-flex items-center gap-1 text-sm font-medium hover:text-brand-600">
-        More
+        Menu
         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
           <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.584l3.71-4.353a.75.75 0 011.14.976l-4.25 5a.75.75 0 01-1.14 0l-4.25-5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
         </svg>
       </button>
       <ul id="dropdownMenu" class="absolute right-0 mt-2 hidden w-48 rounded-md bg-white shadow-lg">
-        <li><a href="employment.html" class="block px-4 py-2 hover:bg-gray-100">Employment Opportunities</a></li>
+        <li><a href="index.html#services" class="block px-4 py-2 hover:bg-gray-100">Services</a></li>
+        <li><a href="index.html#materials" class="block px-4 py-2 hover:bg-gray-100">Materials</a></li>
+        <li><a href="index.html#process" class="block px-4 py-2 hover:bg-gray-100">How&nbsp;It&nbsp;Works</a></li>
+        <li><a href="index.html#contact" class="block px-4 py-2 hover:bg-gray-100">Contact</a></li>
+        <li><a href="employment.html" class="block px-4 py-2 hover:bg-gray-100">Employment</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- make footer text black on white background
- add `Employment` option to the desktop nav bar
- show a mobile dropdown menu with full navigation options

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b3a37a0e0832997860eabc7e51d24