### PR TITLE
Add smooth scrolling for navigation links

### DIFF
--- a/common.js
+++ b/common.js
@@ -5,9 +5,27 @@ document.addEventListener('DOMContentLoaded', () => {
     if (target && nav) {
       const offset = nav.getBoundingClientRect().height;
       const top = target.getBoundingClientRect().top + window.pageYOffset - offset;
-      window.scrollTo({ top });
+      window.scrollTo({ top, behavior: 'smooth' });
     }
   }
+
+  const links = document.querySelectorAll('nav a[href^="#"], nav a[href^="index.html#"]');
+  links.forEach(link => {
+    if (link.getAttribute('href').includes('employment')) return;
+    link.addEventListener('click', event => {
+      event.preventDefault();
+      const href = link.getAttribute('href');
+      const id = href.substring(href.indexOf('#'));
+      const target = document.querySelector(id);
+      const nav = document.querySelector('nav');
+      if (target && nav) {
+        const offset = nav.getBoundingClientRect().height;
+        const top = target.getBoundingClientRect().top + window.pageYOffset - offset;
+        window.scrollTo({ top, behavior: 'smooth' });
+        history.pushState(null, '', id);
+      }
+    });
+  });
 });
 
 function toggleDropdown() {


### PR DESCRIPTION
## Summary
- animate scrolling when navigating to in-page sections
- skip animation for the Employment link

## Testing
- `node --check common.js`

------
https://chatgpt.com/codex/tasks/task_e_685b4906428483299c5ee9371ce11801