### PR TITLE
Fix nav logo linking to homepage

### DIFF
--- a/common.js
+++ b/common.js
@@ -13,8 +13,12 @@ document.addEventListener('DOMContentLoaded', () => {
   links.forEach(link => {
     if (link.getAttribute('href').includes('employment')) return;
     link.addEventListener('click', event => {
-      event.preventDefault();
       const href = link.getAttribute('href');
+      // Allow normal navigation when linking to a different page
+      if (link.pathname && link.pathname !== location.pathname) {
+        return;
+      }
+      event.preventDefault();
       const id = href.substring(href.indexOf('#'));
       const target = document.querySelector(id);
       const nav = document.querySelector('nav');


### PR DESCRIPTION
## Summary
- keep default behavior for nav links that point to a different page
- allow clicking the logo on `employment.html` to navigate back to the homepage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b4b9bb74c83298e49675e2701cbfa