### PR TITLE
Make contact form borders match card style

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,15 +245,15 @@
           <div class="mt-6 space-y-4">
             <label class="block">
               <span class="text-sm font-medium text-black">Name</span>
-              <input required name="name" type="text" class="mt-1 w-full rounded-md border border-black shadow-sm focus:border-brand-500 focus:ring-brand-500" />
+              <input required name="name" type="text" class="mt-1 w-full rounded-md border border-gray-200 shadow-sm focus:border-brand-500 focus:ring-brand-500" />
             </label>
             <label class="block">
               <span class="text-sm font-medium text-black">Email</span>
-              <input required name="email" type="email" class="mt-1 w-full rounded-md border border-black shadow-sm focus:border-brand-500 focus:ring-brand-500" />
+              <input required name="email" type="email" class="mt-1 w-full rounded-md border border-gray-200 shadow-sm focus:border-brand-500 focus:ring-brand-500" />
             </label>
             <label class="block">
               <span class="text-sm font-medium text-black">Message</span>
-              <textarea required name="message" rows="4" class="mt-1 w-full rounded-md border border-black shadow-sm focus:border-brand-500 focus:ring-brand-500"></textarea>
+              <textarea required name="message" rows="4" class="mt-1 w-full rounded-md border border-gray-200 shadow-sm focus:border-brand-500 focus:ring-brand-500"></textarea>
             </label>
             <button type="submit" class="w-full rounded-md bg-brand-600 px-4 py-3 font-semibold text-white hover:bg-brand-700 transition-colors">Send</button>
           </div>


### PR DESCRIPTION
## Summary
- update contact form text field borders to `border-gray-200`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685b4eb8625c8329a450b8ad8d81b63d