### PR TITLE
Fix map copy order

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,16 +204,16 @@
   <section id="map" class="bg-gray-50 py-20 scroll-mt-20">
     <div class="mx-auto max-w-3xl px-6 lg:px-8">
     <h2 class="text-3xl font-bold sm:text-4xl text-center">Get Directions</h2>
-    <div class="mt-4 space-y-4 mb-6 text-black">
+    <div class="rounded-lg shadow-lg overflow-hidden border border-gray-200 mb-6">
+        <!-- Google Maps embed -->
+        <iframe class="w-full h-96" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1623300.215743917!2d-83.52426904375!3d37.3778114!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x884e6bf2af342f7f%3A0x3dc1cd7aa28a6039!2sRecycle%20WV!5e0!3m2!1sen!2sus!4v1750810938652!5m2!1sen!2sus" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+      </div>
+    <div class="mt-4 space-y-4 text-black">
       <p><strong>From 1-77 (West Virginia Turnpike):</strong><br>
       Take exit 9 for US-460W toward Pearisburg VA/Princeton. Travel approx. 1.5 miles on U5-460, then turn right on Locust St. Turn left on Rogers St (WV-104). Turn right on S 2nd St. Turn right on Virginian Industrial Park Rd., then follow signs to RecycleWV.</p>
       <p><strong>From US-460:</strong><br>
       Turn right (westbound) or left (eastbound) on Locust St. Turn left on Rogers St (WV-l 04).Turn right on S 2nd St. Turn right on Virginian Industrial Park Rd., then follow signs to RecycleWV.</p>
     </div>
-    <div class="rounded-lg shadow-lg overflow-hidden border border-gray-200">
-        <!-- Google Maps embed -->
-        <iframe class="w-full h-96" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1623300.215743917!2d-83.52426904375!3d37.3778114!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x884e6bf2af342f7f%3A0x3dc1cd7aa28a6039!2sRecycle%20WV!5e0!3m2!1sen!2sus!4v1750810938652!5m2!1sen!2sus" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- move directional instructions below the embedded map on the homepage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c0274d94883299f33117692b67bb1