### PR TITLE
Add Directions to navigation menu

### DIFF
--- a/employment.html
+++ b/employment.html
@@ -15,6 +15,7 @@
       <li><a href="index.html#services" class="transition-colors hover:text-brand-100">Services</a></li>
       <li><a href="index.html#materials" class="transition-colors hover:text-brand-100">Materials</a></li>
       <li><a href="index.html#process" class="transition-colors hover:text-brand-100">How&nbsp;It&nbsp;Works</a></li>
+      <li><a href="index.html#map" class="transition-colors hover:text-brand-100">Directions</a></li>
       <li><a href="index.html#contact" class="transition-colors hover:text-brand-100">Contact</a></li>
       <li><a href="employment.html" class="transition-colors hover:text-brand-100">Employment</a></li>
     </ul>
@@ -31,6 +32,7 @@
           <li><a href="index.html#services" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Services</a></li>
           <li><a href="index.html#materials" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Materials</a></li>
           <li><a href="index.html#process" class="block px-4 py-2 hover:bg-gray-100 transition-colors">How&nbsp;It&nbsp;Works</a></li>
+          <li><a href="index.html#map" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Directions</a></li>
           <li><a href="index.html#contact" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Contact</a></li>
           <li><a href="employment.html" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Employment</a></li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
       <li><a href="index.html#services" class="transition-colors hover:text-brand-100">Services</a></li>
       <li><a href="index.html#materials" class="transition-colors hover:text-brand-100">Materials</a></li>
       <li><a href="index.html#process" class="transition-colors hover:text-brand-100">How&nbsp;It&nbsp;Works</a></li>
+      <li><a href="index.html#map" class="transition-colors hover:text-brand-100">Directions</a></li>
       <li><a href="index.html#contact" class="transition-colors hover:text-brand-100">Contact</a></li>
       <li><a href="employment.html" class="transition-colors hover:text-brand-100">Employment</a></li>
     </ul>
@@ -32,6 +33,7 @@
           <li><a href="index.html#services" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Services</a></li>
           <li><a href="index.html#materials" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Materials</a></li>
           <li><a href="index.html#process" class="block px-4 py-2 hover:bg-gray-100 transition-colors">How&nbsp;It&nbsp;Works</a></li>
+          <li><a href="index.html#map" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Directions</a></li>
           <li><a href="index.html#contact" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Contact</a></li>
           <li><a href="employment.html" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Employment</a></li>
         </ul>


### PR DESCRIPTION
## Summary
- link to the map section from the main nav bar
- include the same link in the mobile dropdown menu
- update employment page navigation with Directions link

## Testing
- `grep -n "Directions" -n index.html`
- `grep -n "Directions" -n employment.html`


------
https://chatgpt.com/codex/tasks/task_e_685c277426d48329bd78a313dfe163b2