### PR TITLE
Fix smoothscroll reference error

### DIFF
--- a/employment.html
+++ b/employment.html
@@ -71,7 +71,6 @@
     </footer>
 
     <script src="smoothscroll.min.js"></script>
-    <script>smoothscroll.polyfill();</script>
     <script src="common.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -271,7 +271,6 @@
 
   <!-- Smooth‑scroll polyfill for Safari / iOS -->
   <script src="smoothscroll.min.js"></script>
-  <script>smoothscroll.polyfill();</script>
   <script src="common.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove `smoothscroll.polyfill()` calls from HTML

## Testing
- `python3 -m http.server 8000` *(fails: Address already in use)*
- `curl -I http://localhost:8000/`
- `curl -I http://localhost:8000/employment.html`
- `curl -I http://localhost:8000/smoothscroll.min.js`

------
https://chatgpt.com/codex/tasks/task_e_685c46cd48a08329b9bc6eb79ee706ad